### PR TITLE
Use the SQLAlchemy Core for queries

### DIFF
--- a/bookserver/db.py
+++ b/bookserver/db.py
@@ -14,7 +14,7 @@
 # Third-party imports
 # -------------------
 # Use asyncio for SQLAlchemy -- see `SQLAlchemy Asynchronous I/O (asyncio) <https://docs.sqlalchemy.org/en/14/orm/extensions/asyncio.html>`_.
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.ext.declarative import declarative_base, DeclarativeMeta
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm import sessionmaker
@@ -45,8 +45,16 @@ engine = create_async_engine(DATABASE_URL, connect_args=connect_args, echo=True)
 # This creates the SessionLocal class.  An actual session is an instance of this class.
 async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
+
+# Provide easy access to a declarative class's Table (Core) attribute.
+class CoreDeclarativeMeta(DeclarativeMeta):
+    @property
+    def t(cls):
+        return cls.__table__
+
+
 # This creates the base class we will use to create models
-Base = declarative_base()
+Base = declarative_base(metaclass=CoreDeclarativeMeta)
 
 
 async def init_models():

--- a/bookserver/models.py
+++ b/bookserver/models.py
@@ -102,11 +102,6 @@ def register_answer_table(cls):
 class IdMixin:
     id = Column(Integer, primary_key=True)
 
-    @classmethod
-    @property
-    def t(cls):
-        return cls.__table__
-
 
 # Useinfo
 # -------

--- a/bookserver/models.py
+++ b/bookserver/models.py
@@ -102,6 +102,11 @@ def register_answer_table(cls):
 class IdMixin:
     id = Column(Integer, primary_key=True)
 
+    @classmethod
+    @property
+    def t(cls):
+        return cls.__table__
+
 
 # Useinfo
 # -------

--- a/bookserver/routers/assessment.py
+++ b/bookserver/routers/assessment.py
@@ -53,9 +53,8 @@ async def get_assessment_results(request_data: AssessmentRequest):
     if not row:
         return ""  # server doesn't have it so we load from local storage instead
 
-    # construct the return value from the XXXAnswer class
-    # TODO: Seems like something like this should be built in to sqlalchemy?
-    res = row.to_dict()
+    # Get the return dict from the query.
+    res = row._mapping
 
     # :index:`todo``: **port the serverside grading** code::
     #

--- a/conf.py
+++ b/conf.py
@@ -181,6 +181,7 @@ exclude_patterns = [
     "**/.mypy_cache",
     ".mypy_cache",
     "poetry.lock",
+    ".tox",
     # **CodeChat notes:**
     #
     # By default, Enki will instruct Sphinx to place all Sphinx output in

--- a/index.rst
+++ b/index.rst
@@ -27,6 +27,7 @@ Development support
     .gitignore
     .flake8
     mypy.ini
+    tox.ini
 
 
 Documentation generation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ sphinx-rtd-theme = "^0.5.2"
 mypy = "^0.812"
 coverage = "^5.3.1"
 pytest-cov = "^2.10.1"
+tox = "^3.23.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+# *********
+# |docname|
+# *********
+[tox]
+envlist = py38, py39
+isolated_build = True
+
+[testenv]
+whitelist_externals = poetry
+
+# Install test dependencies, per the `tox docs <https://tox.readthedocs.io/en/latest/config.html#conf-extras>`_.
+commands =
+    poetry install -v
+    poetry run pytest


### PR DESCRIPTION
In general, we don't want to allow ORM objects to "escape" from `crud.py`, so avoid the possibility of unintentional changes to these variables produces actual changes in the database.

One approach is to query using the ORM, then convert the results into a Pydantic struct. A simpler solution is to query the Core:
- The query syntax is very, very similar.
- The results from the query can be returned directly outside this module, automatically preventing ORM escapes.
- It's less error-prone (whoops! Forgot to wrap that ORM result before returning it...)
- It's probably a bit faster.

I found out (the hard way) that my initial solution used a Python 3.9-only feature. I also added `tox` to make it easier to test across multiple Python versions.