### PR TITLE
Add: tox.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -18,6 +18,6 @@ ignore=
   E501,
 
 exclude =
-  # Ignore Sphinx build output.
   _build/
   alembic/
+  .tox/

--- a/conf.py
+++ b/conf.py
@@ -181,6 +181,7 @@ exclude_patterns = [
     "**/.mypy_cache",
     ".mypy_cache",
     "poetry.lock",
+    ".tox",
     # **CodeChat notes:**
     #
     # By default, Enki will instruct Sphinx to place all Sphinx output in

--- a/index.rst
+++ b/index.rst
@@ -27,6 +27,7 @@ Development support
     .gitignore
     .flake8
     mypy.ini
+    tox.ini
 
 
 Documentation generation

--- a/mypy.ini
+++ b/mypy.ini
@@ -26,7 +26,7 @@
 [mypy]
 # See `files <https://mypy.readthedocs.io/en/stable/config_file.html#confval-files>`_.
 files = .
-exclude = (^_build/)|(^alembic/)
+exclude = (^_build/)|(^alembic/)|(^.tox/)
 # See https://pydantic-docs.helpmanual.io/mypy_plugin/#enabling-the-plugin.
 plugins = pydantic.mypy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ sphinx-rtd-theme = "^0.5.2"
 mypy = "^0.812"
 coverage = "^5.3.1"
 pytest-cov = "^2.10.1"
+tox = "^3.23.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+# *********
+# |docname|
+# *********
+# See Poetry's docs <https://python-poetry.org/docs/faq/#is-tox-supported>`_ on integration with tox.
+[tox]
+envlist = py38, py39
+isolated_build = True
+
+[testenv]
+allowlist_externals = poetry
+
+commands =
+    poetry install -v
+    poetry run pytest


### PR DESCRIPTION
I tried using tox to replace the `pre_commit_check.py` script, but it was slow -- it needed to re-install the current project in its venv before running it, then update the poetry environment. For now, I'll add tox but not use it to run commands (although I like the idea).