### PR TITLE
Improve logging

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -9,6 +9,7 @@
 #
 # Standard library
 # ----------------
+import logging
 from logging.config import fileConfig
 from textwrap import dedent
 
@@ -25,6 +26,8 @@ from bookserver.config import settings
 
 # Configuration
 # =============
+logger = logging.getLogger(__name__)
+
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
@@ -44,7 +47,7 @@ target_metadata = models.Base.metadata
 
 # Use the non-async flavor of the provided database URL.
 dburl = settings.database_url.replace("+asyncpg", "").replace("+aiosqlite", "")
-print(f"Using DBURL of {dburl}.\n")
+logger.info(f"Using DBURL of {dburl}.")
 
 # Compute tables not to migrate
 # -----------------------------

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -9,7 +9,6 @@
 #
 # Standard library
 # ----------------
-import logging
 from logging.config import fileConfig
 from textwrap import dedent
 
@@ -21,13 +20,11 @@ from sqlalchemy import create_engine
 # Local application imports
 # -------------------------
 from bookserver import models
+from bookserver.applogger import rslogger
 from bookserver.config import settings
-
 
 # Configuration
 # =============
-logger = logging.getLogger(__name__)
-
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
@@ -47,7 +44,7 @@ target_metadata = models.Base.metadata
 
 # Use the non-async flavor of the provided database URL.
 dburl = settings.database_url.replace("+asyncpg", "").replace("+aiosqlite", "")
-logger.info(f"Using DBURL of {dburl}.")
+rslogger.info(f"Using DBURL of {dburl}.")
 
 # Compute tables not to migrate
 # -----------------------------

--- a/bookserver/db.py
+++ b/bookserver/db.py
@@ -9,8 +9,8 @@
 #
 # Standard library
 # ----------------
-import logging
-
+# None.
+#
 # Third-party imports
 # -------------------
 # Use asyncio for SQLAlchemy -- see `SQLAlchemy Asynchronous I/O (asyncio) <https://docs.sqlalchemy.org/en/14/orm/extensions/asyncio.html>`_.
@@ -22,9 +22,8 @@ from sqlalchemy.sql import select
 # Local application imports
 # -------------------------
 from .config import settings, BookServerConfig, DatabaseType
+from .applogger import rslogger
 
-
-logger = logging.getLogger(__name__)
 
 if settings.database_type == DatabaseType.SQLite:
     connect_args = {"check_same_thread": False}
@@ -60,7 +59,7 @@ async def init_models():
 
 # Look for any records that violate non-null constraints.
 async def check_not_null():
-    logger.info("Searching for NOT NULL constraint violations..."),
+    rslogger.info("Searching for NOT NULL constraint violations..."),
     not_null_count = 0
     async with async_session() as session:
         for table_name, table in Base.metadata.tables.items():
@@ -71,7 +70,7 @@ async def check_not_null():
                     res = (await session.execute(query)).fetchall()
                     if res:
                         not_null_count += 1
-                        logger.error(
+                        rslogger.error(
                             f"Column {table_name}.{column.key} has {len(res)} NULL records, such as:"
                         )
                         for row in res[0:9]:
@@ -82,8 +81,8 @@ async def check_not_null():
 
                             # The result isn't an ORM object, so use this to display it.
                             s = ", ".join(f"{k}={shorten(row[k])}" for k in row.keys())
-                            logging.error(f"  {s}")
-    logger.info(f"Done; found {not_null_count} columns with constraint violations.")
+                            rslogger.error(f"  {s}")
+    rslogger.info(f"Done; found {not_null_count} columns with constraint violations.")
 
 
 # If the engine isn't disposed of, then a PostgreSQL database will remain in a pseudo-locked state, refusing to drop of truncate tables (see `bookserver_session`).

--- a/bookserver/main.py
+++ b/bookserver/main.py
@@ -10,7 +10,6 @@
 # Standard library
 # ----------------
 import json
-import logging
 
 # Third-party imports
 # -------------------
@@ -37,9 +36,8 @@ from .session import auth_manager
 
 # FastAPI setup
 # =============
-logger = logging.getLogger(__name__)
 app = FastAPI()
-logger.info(f"Serving books from {settings.book_path}.\n")
+rslogger.info(f"Serving books from {settings.book_path}.\n")
 
 # Install the auth_manager as middleware This will make the user
 # part of the request ``request.state.user`` `See FastAPI_Login Advanced <https://fastapi-login.readthedocs.io/advanced_usage/>`_

--- a/bookserver/main.py
+++ b/bookserver/main.py
@@ -10,6 +10,7 @@
 # Standard library
 # ----------------
 import json
+import logging
 
 # Third-party imports
 # -------------------
@@ -36,8 +37,9 @@ from .session import auth_manager
 
 # FastAPI setup
 # =============
+logger = logging.getLogger(__name__)
 app = FastAPI()
-print(f"Serving books from {settings.book_path}.\n")
+logger.info(f"Serving books from {settings.book_path}.\n")
 
 # Install the auth_manager as middleware This will make the user
 # part of the request ``request.state.user`` `See FastAPI_Login Advanced <https://fastapi-login.readthedocs.io/advanced_usage/>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,3 +86,5 @@ addopts = "--ignore=_build"
 env = [
     "BOOK_SERVER_CONFIG=test",
 ]
+# The _`default logging level` of INFO produces a LOT of output. Use a higher level of ``WARNING`` to reduce the noise.
+log_cli_level = 30

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -154,8 +154,8 @@ def run_bookserver(pytestconfig):
             os.environ["DBHOST"] = pgnetloc
 
             try:
-                subprocess.run("dropdb --if-exists", check=True)
-                subprocess.run(f"createdb --echo {dbname}", check=True)
+                subprocess.run("dropdb --if-exists", check=True, shell=True)
+                subprocess.run(f"createdb --echo {dbname}", check=True, shell=True)
             except Exception as e:
                 assert (
                     False
@@ -192,7 +192,7 @@ def run_bookserver(pytestconfig):
             m.setenv("TEST_DBURL", sync_dburl)
 
             def run_subprocess(args: str, description: str):
-                cp = subprocess.run(args, capture_output=True, text=True)
+                cp = subprocess.run(args, capture_output=True, text=True, shell=True)
                 log_subprocess(cp.stdout, cp.stderr, description)
 
             run_subprocess(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -205,7 +205,7 @@ def run_bookserver(pytestconfig):
     # Start the bookserver and the scheduler.
     prefix_args = []
     # Pass pytest's log level to Celery; if not specified, it defaults to INFO.
-    log_level = pytestconfig.getoption('log_cli_level') or 'INFO'
+    log_level = pytestconfig.getoption("log_cli_level") or "INFO"
     if pytestconfig.getoption("server_debug"):
         # Don't redirect stdio, so the developer can see and interact with it.
         kwargs = {}

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -111,7 +111,7 @@ def pytest_addoption(parser):
 def pytest_terminal_summary(terminalreporter):
     cov.stop()
     cov.save()
-    # Combine this (pytest) coverage with the webserver coverage. Use a new object, since the ``cov`` object is tried to the data file produced by the pytest run. Otherwise, the report is correct, but the resulting ``.coverage`` data file is empty.
+    # Combine this (pytest) coverage with the webserver coverage. Use a new object, since the ``cov`` object is tied to the data file produced by the pytest run. Otherwise, the report is correct, but the resulting ``.coverage`` data file is empty.
     cov_all = coverage.Coverage()
     cov_all.combine()
 

--- a/test/toctree.rst
+++ b/test/toctree.rst
@@ -1,7 +1,18 @@
 **************************
 Testing for the BookServer
 **************************
-To run the tests, execute ``poetry run pytest`` from the parent of this subdirectory; running them here causes code coverage failures.
+To run the tests, execute ``poetry run pytest`` from the parent of this subdirectory; running them here causes code coverage failures. There are several important command-line options:
+
+--skipdbinit    Skip initialization of the test database. This makes the tests start much faster, at the risk of a corrupt database causing spurious test failures.
+--server_debug  Enable server debug mode. This runs the server in a separate terminal/console, which allow you to set breakpoints, stop the code, etc.
+--log_cli_level LEVEL   Set the `pytest logging level <https://docs.pytest.org/en/6.2.x/logging.html#live-logs>`_. This level affects not just pytest, but the server and all tools run by the tests. Use ``--log_cli_level=INFO`` to provide complete output from the server; the `default logging level <default logging level>` is ``WARNING``.
+--k EXPRESSION   Only run tests which match the given substring expression. For example, ``-k test_foo`` only runs tests named ``test_foo``, ``test_foo_1``, etc. See the `pytest docs <https://docs.pytest.org/en/6.2.x/usage.html#specifying-tests-selecting-tests>`_ for more possibilities.
+
+Testing and debugging tips:
+
+-   To help track down errors, you may insert a breakpoint at any point in the test code; simply insert the line ``import pdb; pdb.set_trace()`` and the test will enter the `Python debugger <https://docs.python.org/3/library/pdb.html#debugger-commands>`_.
+-   The same technique works on the server, but you must also specify the ``--server_debug`` option so you can debug the server in its own window.
+-   For Selenium-based tests (which run in a separate Chrome browser), you can also interact with Chrome as usual -- open the JavaScript console, set breakpoints, etc. Be sure to set a breakpoint in the test code, so you'll have more than the default 10 second timeout to explore. When done, navigate to the window you ran pytest in then type ``c`` and press enter to tell the Python debugger to continue running tests.
 
 Here is the `pytest configuration`.
 


### PR DESCRIPTION
This will help us more easily control how much info we want from a test session.

**WARNING** I set the default log level to `WARNING` instead of `INFO` to suppress most log noise by default. But there's always the chance there was something important in those details. Use `pytest --log-cli-level=INFO` to see lots more stuff.