### PR TITLE
WIP: deploy using nginx

### DIFF
--- a/bookserver/nginx.conf
+++ b/bookserver/nginx.conf
@@ -1,0 +1,109 @@
+# ***********************************
+# |docname| - configuration for nginx
+# ***********************************
+# This sets up nginx to run both the old and new server together.
+#
+# It was partially taken from the `gunicorn docs <https://docs.gunicorn.org/en/stable/deploy.html#nginx-configuration>`_.
+worker_processes 1;
+
+user nobody nogroup;
+# 'user nobody nobody;' for systems with 'nobody' as a group instead
+error_log  /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+events {
+  # increase if you have lots of clients
+  worker_connections 1024;
+  # set to 'on' if nginx worker_processes > 1
+  accept_mutex off;
+  # 'use epoll;' to enable for Linux 2.6+
+  # 'use kqueue;' to enable for FreeBSD, OSX
+}
+
+http {
+  include mime.types;
+  # fallback in case we can't determine a type
+  default_type application/octet-stream;
+  access_log /var/log/nginx/access.log combined;
+  sendfile on;
+
+  upstream app_server {
+    # fail_timeout=0 means we always retry an upstream even if it failed
+    # to return a good HTTP response
+
+    # for UNIX domain socket setups
+    server unix:/tmp/gunicorn.sock fail_timeout=0;
+
+    # for a TCP configuration
+    # server 192.168.0.7:8000 fail_timeout=0;
+  }
+
+  server {
+    # if no Host match, close the connection to prevent host spoofing
+    listen 80 default_server;
+    return 444;
+  }
+
+  server {
+    # use 'listen 80 deferred;' for Linux
+    # use 'listen 80 accept_filter=httpready;' for FreeBSD
+    listen 80;
+    client_max_body_size 4G;
+
+    # set the correct host(s) for your site
+    server_name example.com www.example.com;
+
+    keepalive_timeout 5;
+
+    # path for static files
+    root /path/to/app/current/public;
+
+    location / {
+      # checks for static file, if not found proxy to app
+      try_files $uri @proxy_to_app;
+    }
+
+    location @proxy_to_app {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header Host $http_host;
+      # we don't want nginx trying to do something clever with
+      # redirects, we set the Host: header above already.
+      proxy_redirect off;
+      proxy_pass http://app_server;
+    }
+
+    error_page 500 502 503 504 /500.html;
+    location = /500.html {
+      root /path/to/app/current/public;
+    }
+  }
+}
+
+
+
+
+
+server {
+    listen  80 default_server;
+    include /etc/nginx/default.d/*.conf;
+
+    # Rewrite the path to static files.
+    # root supplies the uptree path the match gets appended to the path specified
+    # by the root directive
+    location ~* /(\w+)/static/ {
+        root /srv/web2py/applications/;
+    }
+
+    # alias allows us to completely rewrite the static path
+    location ~* /(\w+)/books/(published|draft)/(\w+)/(_static|_images|images)/(.*)$ {
+        alias /srv/web2py/applications/$1/books/$3/$2/$3/$4/$5;
+    }
+
+    location / {
+        include uwsgi_params;
+        uwsgi_pass unix:/run/uwsgi/web2py.sock;
+        uwsgi_param	DBURL	postgresql://runestone:passworda@localhost/runestone;
+        uwsgi_param     WEB2PY_CONFIG development;
+    }
+}


### PR DESCRIPTION
I won't be able to look at this until tomorrow at the earliest, since since is my big teaching day (plus tomorrow morning). Here's my (small) amount of progress, in case you want to play, along with my approach / plans.

- [ ] Handle HTTPS connections; forward HTTP to web2py/fastapi
- [ ] Serve static files -- the existing regexes for web2py should be fine. There's no regex possible for fastAPI, since the URLs refer to the course name instead of the base course name.
- [ ] Mount gnunicorn, which runs uvicorn, which runs FastAPI, which runs the BookServer at `/fa`. We already have code to run gunicorn + uvicorn + fastAPI + BookServer (in `__main__.py`). The top half of the config file was copied from gunicorn deployment docs.
- [ ] Mount uwsgi and its web2py connection at the `/` (root) directory. Hopefully, this means just using the existing nginx config (at the bottom of the `nginx.conf` file in this PR.